### PR TITLE
Added top level elisp file that requires monte.el and monte-indent.el

### DIFF
--- a/elisp/monte.el
+++ b/elisp/monte.el
@@ -1,4 +1,4 @@
-;; monte.el -- support for editing Monte code -*- lexical-binding: t -*-
+;; monte.el --- support for editing Monte code -*- lexical-binding: t -*-
 ;; copyright 2015 Allen Short, available under MIT license (see LICENSE)
 (provide 'monte)
 ;;;###autoload

--- a/monte-emacs.el
+++ b/monte-emacs.el
@@ -1,3 +1,4 @@
+;;; monte-emacs.el --- support for editing Monte code
 (provide 'monte-emacs)
 (push (expand-file-name "elisp/" (file-name-directory load-file-name)) load-path)
 (require 'monte)

--- a/monte-emacs.el
+++ b/monte-emacs.el
@@ -1,0 +1,4 @@
+(provide 'monte-emacs)
+(push (expand-file-name "elisp/" (file-name-directory load-file-name)) load-path)
+(require 'monte)
+(require 'monte-indent)


### PR DESCRIPTION
This makes the library behave as an emacs package (`monte-emacs`), which makes it much simpler to use with spacemacs and/or use-package.